### PR TITLE
Remove erroneous .md suffix from LICENSE link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then update:
     - Add details appropriate to your new repo (e.g. replace this getting started section!)
     - Update the license date to be the year your repo was created.
 
- - **[LICENCE](LICENCE.md)**
+ - **[LICENCE](LICENCE)**
     - Update the license date to be the year your repo was created
 
 ### Integrations


### PR DESCRIPTION
## What? and Why?
  - Fixes the extension used in the LICENSE link in the readme. Required as the old link was incorrect and gave a 404
