### PR TITLE
Add .gitignore covering python and golang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+## --------------- PYTHON
+.DS_Store
+tests/__pycache__/
+__pycache__
+logs/validate.log
+*.pyc
+bin/
+include/
+lib/
+.Python
+pip-selfcheck.json
+
+## --------------- GO
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+## --------------- CODECOV
+coverage.xml
+.coverage


### PR DESCRIPTION
## What? and Why?
  - Adds a standard .gitignore to cover files used by _python_ and _golang_ so these don't need to be manually added by consumers of this template.
